### PR TITLE
CentOS 8 support

### DIFF
--- a/calcPv/calcPerform.c
+++ b/calcPv/calcPerform.c
@@ -5,7 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * EPICS BASE Versions 3.13.7
 * and higher are distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution. 
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* calcPerform.c,v 1.37.2.5 2006/11/30 22:29:08 jhill Exp */
 /*
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <errlog.h>
 
 #include "postfix.h"
 #include "postfixPvt.h"

--- a/giflib/Makefile
+++ b/giflib/Makefile
@@ -31,7 +31,7 @@ GIF_INC ?= /usr/include
    USR_SYS_LIBS_solaris += pthread dl rt ungif gif
 
    USR_LIBS_hpux11_11_mt = Xm Xt X11 Xext
-   USR_SYS_LIBS_hpux11_11_mt = pthread gif
+   USR_SYS_LIBS_hpux11_11_mt = pthread ungif gif
 
    LIBRARY = cf322683-513e-4570-a44b-7cdd7cae0de5
 

--- a/giflib/Makefile
+++ b/giflib/Makefile
@@ -25,10 +25,10 @@ GIF_INC ?= /usr/include
    USR_SYS_LIBS_Linux += pthread dl gif
 
    USR_LIBS_Darwin += Xm Xt Xtst X11
-   USR_SYS_LIBS_Darwin += pthread dl gif
+   USR_SYS_LIBS_Darwin += pthread dl ungif gif
 
    USR_LIBS_solaris += Xm Xt Xmu X11 Xext
-   USR_SYS_LIBS_solaris += pthread dl rt gif
+   USR_SYS_LIBS_solaris += pthread dl rt ungif gif
 
    USR_LIBS_hpux11_11_mt = Xm Xt X11 Xext
    USR_SYS_LIBS_hpux11_11_mt = pthread gif

--- a/giflib/Makefile
+++ b/giflib/Makefile
@@ -22,16 +22,16 @@ GIF_INC ?= /usr/include
    USR_LIBS += 114135a4-6f6c-11d3-95bc-00104b8742df
 
    USR_LIBS_Linux += Xm Xt Xtst X11
-   USR_SYS_LIBS_Linux += pthread dl ungif gif
+   USR_SYS_LIBS_Linux += pthread dl gif
 
    USR_LIBS_Darwin += Xm Xt Xtst X11
-   USR_SYS_LIBS_Darwin += pthread dl ungif gif
+   USR_SYS_LIBS_Darwin += pthread dl gif
 
    USR_LIBS_solaris += Xm Xt Xmu X11 Xext
-   USR_SYS_LIBS_solaris += pthread dl rt ungif gif
+   USR_SYS_LIBS_solaris += pthread dl rt gif
 
    USR_LIBS_hpux11_11_mt = Xm Xt X11 Xext
-   USR_SYS_LIBS_hpux11_11_mt = pthread ungif gif
+   USR_SYS_LIBS_hpux11_11_mt = pthread gif
 
    LIBRARY = cf322683-513e-4570-a44b-7cdd7cae0de5
 
@@ -60,13 +60,13 @@ GIF_INC ?= /usr/include
    HCLXt_DIR = $(X11_LIB)
    Xlib_DIR = $(X11_LIB)
    HCLXmu_DIR = $(X11_LIB)
-   
+
 
    LIB_SRCS += gif.cc
    LIB_SRCS += reg_libcf322683-513e-4570-a44b-7cdd7cae0de5.cc
-   
+
    include $(TOP)/configure/RULES
-   
+
 else
    ifneq ($(wildcard $(TOP)/config)x,x)
      # New Makefile.Host config file location


### PR DESCRIPTION
Feel free to not approve, I may have missed something.

I was having issues compiling this in CentOS 8 using:

1.  [these](https://docs.epics-controls.org/projects/how-tos/en/latest/getting-started/linux-packages.html) packges
2. gcc 8.3.1
3. GNU Make 4.2.1

I had to modify `calcPerform.c`  by including `errlog.h` and removing `ungif` from the giflib makefile. I am now able to compile and run.